### PR TITLE
All the filter button to be hidden completely, not just the badge

### DIFF
--- a/paper-search-bar.html
+++ b/paper-search-bar.html
@@ -63,7 +63,7 @@ Bar in which the user can enter search terms and filter
 			<input is="iron-input" id="input" bind-value="{{query}}" placeholder="[[placeholder]]" class="flex" disabled="[[!_enabled]]"></input>
 		</div>
 		<paper-icon-button icon="clear" hidden$="[[!query]]" on-tap="_clear" class="icon"></paper-icon-button>
-		<paper-icon-button id="filter" icon="image:tune" on-tap="_filter" class="icon"></paper-icon-button>
+		<paper-icon-button id="filter" hidden$="[[hideFilterButton]]" icon="image:tune" on-tap="_filter" class="icon"></paper-icon-button>
 		<paper-badge for="filter" label="[[nrSelectedFilters]]" class="badge" hidden$="[[!nrSelectedFilters]]"></paper-badge>
 	</template>
 
@@ -96,6 +96,13 @@ Bar in which the user can enter search terms and filter
 				notify: true,
 				value: ''
 			},
+            /**
+             * Whether to hide the Filter button.  Set attribute "hide-filter-button" to do so.
+             */
+            hideFilterButton: {
+                type: Boolean,
+                value: false
+            },
 			/**
 			 * Number of filters the user has been selected (shown in the badge) (optional)
 			 */


### PR DESCRIPTION
Hi, I wanted to be able to hide the filter button on paper-search-bar completely so I've added a property to do so, 'hideFilterButton'.  Setting this in markup as the dashed equivalent now hides it completely:

`<paper-search-bar hide-filter-button placerholder="Enter query"></paper-search-bar>`
