### PR TITLE
Fix Filter dialog button's alignment on search-bar

### DIFF
--- a/paper-search-bar.html
+++ b/paper-search-bar.html
@@ -6,6 +6,7 @@
 <link rel="import" href="../iron-icons/image-icons.html">
 <link rel="import" href="../iron-input/iron-input.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="../paper-badge/paper-badge.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
 <link rel="import" href="../paper-styles/default-theme.html">
@@ -18,7 +19,7 @@ Bar in which the user can enter search terms and filter
 <dom-module id="paper-search-bar">
 
 	<template>
-		<style>
+		<style include="iron-flex">
 			:host {
 				background: var(--background-color, white);
 				display: block;


### PR DESCRIPTION
The PR fixes the incorrect alignment of Filter dialog button on search-bar after release 1.2.2.
Elements in search-bar use "flex" class but iron-flex-layout-classes.html is not imported. "iron-style" should also be included in style tag.
